### PR TITLE
Retrieve weve data from optimistic cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 .env
+.DS_Store

--- a/src/getTxid.ts
+++ b/src/getTxid.ts
@@ -1,24 +1,29 @@
 import { T_txid, T_weeve } from "./types";
 import {arweave, ardb} from './arweave';
+import ArdbTransaction from "ardb/lib/models/transaction";
 
 const getTxid = async (txid: T_txid): Promise<T_weeve> => {
   let weeveData = null;
   try {
-    const tx = await ardb.search('transactions')
+    const tx = <ArdbTransaction> await ardb.search('transactions')
       .ids([txid])
       .findOne();
 
-    const data = await arweave.transactions.getData(tx.id, {decode: true, string: true});
+    // get the tx data from the optimistic cache
+    const response = await arweave.api.get(`${tx.id}`)
+    const data = response.data;
+
+    // retrieve the community the weeve was posted in
     let community = 'tags' in tx ? tx.tags.find(tag => tag.name === 'community')?.value : undefined;
 
-    if('owner' in tx && 'id' in tx && typeof data === "string"){
-      let _data = JSON.parse(data)._data;
+    if(tx.owner?.address && tx.id && typeof data === "object"){
+      let _data = data._data;
       weeveData = {
         id: tx.id,
         text: _data.text,
         picture: _data.pictures ? _data.pictures[0] : null,
         jwk: tx.owner.address,
-        time: 'block' in tx ? tx.block?.timestamp : undefined,
+        time: tx.block?.timestamp,
         community: community
       };
     }


### PR DESCRIPTION
- Simplifies the ardb transaction integration
- Retrieves weve data from the optimistic cache.

This change doesn't try to fall back to requesting data from the nodes via `getData(txid)` because requesting data from the optimistic cache causes the gateway to request it from the nodes if it's not in the cache.