### PR TITLE
Update logo to use gradient branding

### DIFF
--- a/public/metaweave-gradient-dark.svg
+++ b/public/metaweave-gradient-dark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 400 400" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <circle cx="200" cy="200" r="200" style="stroke:black;stroke-width:2px;"/>
+    <path d="M58,90L202,164L204,189L231,199L251,187L260,176L280,172L305,184L337,192L302,209L287,225L266,264L225,286L198,290L192,307L135,316L87,301L62,273L51,246L129,252L141,243L133,242L133,233L99,222L68,182L53,141L58,90ZM63,100L195,168L198,194L232,206L256,192L263,182L279,178L298,188L321,194L302,201L284,218L262,258L223,279L177,288L188,292L188,300L132,308L94,296L66,265L64,255L129,260L146,250L187.925,244.062L191,243L142,236L142,229L104,215L75,179L61,142L63,100ZM269,192L273,187L277,191L275,194L271,194L269,192ZM221,185L217,186L213,183L261,119L349,84L299,170L296,171L291,169L334,97L265,124L221,185Z" style="fill:url(#_Linear1);stroke:url(#_Linear2);stroke-width:2px;"/>
+    <defs>
+        <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-223,232,-180.617,-173.611,344,95)"><stop offset="0" style="stop-color:rgb(255,0,191);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(206,0,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear2" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-239,226,-175.946,-186.067,350,83)"><stop offset="0" style="stop-color:rgb(255,0,186);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(206,0,255);stop-opacity:1"/></linearGradient>
+    </defs>
+</svg>

--- a/public/metaweave-gradient-dark.svg
+++ b/public/metaweave-gradient-dark.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 400 400" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
-    <circle cx="200" cy="200" r="200" style="stroke:black;stroke-width:2px;"/>
+    <!-- <circle cx="200" cy="200" r="200" style="stroke:black;stroke-width:2px;"/> -->
     <path d="M58,90L202,164L204,189L231,199L251,187L260,176L280,172L305,184L337,192L302,209L287,225L266,264L225,286L198,290L192,307L135,316L87,301L62,273L51,246L129,252L141,243L133,242L133,233L99,222L68,182L53,141L58,90ZM63,100L195,168L198,194L232,206L256,192L263,182L279,178L298,188L321,194L302,201L284,218L262,258L223,279L177,288L188,292L188,300L132,308L94,296L66,265L64,255L129,260L146,250L187.925,244.062L191,243L142,236L142,229L104,215L75,179L61,142L63,100ZM269,192L273,187L277,191L275,194L271,194L269,192ZM221,185L217,186L213,183L261,119L349,84L299,170L296,171L291,169L334,97L265,124L221,185Z" style="fill:url(#_Linear1);stroke:url(#_Linear2);stroke-width:2px;"/>
     <defs>
         <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-223,232,-180.617,-173.611,344,95)"><stop offset="0" style="stop-color:rgb(255,0,191);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(206,0,255);stop-opacity:1"/></linearGradient>

--- a/public/styles.css
+++ b/public/styles.css
@@ -95,6 +95,6 @@ img {
     color: white;
   }
   img {
-    content: url('metaweave-dark.svg');
+    content: url('metaweave-gradient-dark.svg');
   }
 }

--- a/src/getHtml.ts
+++ b/src/getHtml.ts
@@ -12,7 +12,7 @@ export async function generateWalletImage(address: T_address) {
   <svg width="100%" height="100%" viewBox="0 0 800 800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
       <rect x="-1" y="0" width="801" height="800"/>
       <g transform="matrix(1,0,0,1,-121,346)">
-          <text x="214.782px" y="308.684px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:144px;fill:white;">${shortAddress}</text>
+          <text x="160px" y="308.684px" textLength="90%" style="font-family:Monospace, sans-serif;font-size:140px;fill:white;">${shortAddress}</text>
       </g>
       <g transform="matrix(1.72148,0,0,1.72148,67.2047,-60.604)">
           <path d="M58,90L202,164L204,189L231,199L251,187L260,176L280,172L305,184L337,192L302,209L287,225L266,264L225,286L198,290L192,307L135,316L87,301L62,273L51,246L129,252L141,243L133,242L133,233L99,222L68,182L53,141L58,90ZM63,100L195,168L198,194L232,206L256,192L263,182L279,178L298,188L321,194L302,201L284,218L262,258L223,279L177,288L188,292L188,300L132,308L94,296L66,265L64,255L129,260L146,250L187.925,244.062L191,243L142,236L142,229L104,215L75,179L61,142L63,100ZM269,192L273,187L277,191L275,194L271,194L269,192ZM221,185L217,186L213,183L261,119L349,84L299,170L296,171L291,169L334,97L265,124L221,185Z" style="fill:url(#_Linear1);stroke:url(#_Linear2);stroke-width:1.16px;"/>

--- a/src/getHtml.ts
+++ b/src/getHtml.ts
@@ -9,12 +9,20 @@ export async function generateWalletImage(address: T_address) {
   let shortAddress = `${address.substring(0,3)}...${address.substring(address.length-3)}`;
   const svgBuffer =  Buffer.from(`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
   <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-  <svg width="100%" height="100%" viewBox="0 0 800 800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-      <rect x="0" y="0" width="800" height="800"/>
-      <g transform="matrix(1,0,0,1,-121,123)">
-          <text x="214px" y="310px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:144px;fill:white;">${shortAddress}</text>
+  <svg width="100%" height="100%" viewBox="0 0 800 800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+      <rect x="-1" y="0" width="801" height="800"/>
+      <g transform="matrix(1,0,0,1,-121,346)">
+          <text x="214.782px" y="308.684px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:144px;fill:white;">${shortAddress}</text>
       </g>
+      <g transform="matrix(1.72148,0,0,1.72148,67.2047,-60.604)">
+          <path d="M58,90L202,164L204,189L231,199L251,187L260,176L280,172L305,184L337,192L302,209L287,225L266,264L225,286L198,290L192,307L135,316L87,301L62,273L51,246L129,252L141,243L133,242L133,233L99,222L68,182L53,141L58,90ZM63,100L195,168L198,194L232,206L256,192L263,182L279,178L298,188L321,194L302,201L284,218L262,258L223,279L177,288L188,292L188,300L132,308L94,296L66,265L64,255L129,260L146,250L187.925,244.062L191,243L142,236L142,229L104,215L75,179L61,142L63,100ZM269,192L273,187L277,191L275,194L271,194L269,192ZM221,185L217,186L213,183L261,119L349,84L299,170L296,171L291,169L334,97L265,124L221,185Z" style="fill:url(#_Linear1);stroke:url(#_Linear2);stroke-width:1.16px;"/>
+      </g>
+      <defs>
+          <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-223,232,-180.617,-173.611,344,95)"><stop offset="0" style="stop-color:rgb(255,0,191);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(206,0,255);stop-opacity:1"/></linearGradient>
+          <linearGradient id="_Linear2" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-239,226,-175.946,-186.067,350,83)"><stop offset="0" style="stop-color:rgb(255,0,186);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(206,0,255);stop-opacity:1"/></linearGradient>
+      </defs>
   </svg>
+  
   `);
   let buff = await sharp(svgBuffer)
     .resize(800,800)
@@ -60,7 +68,7 @@ export async function forWeeve (weeve: T_weeve) {
         <div id="subdomain">
           account
         </div>
-        <img src="/metaweave-dark.svg" alt="metaweave logo">
+        <img src="/metaweave-gradient-dark.svg" alt="metaweave logo">
         <div id="text">
           metaweave.xyz
         </div>
@@ -110,7 +118,7 @@ export async function forProfile (basePath:string, address: T_address) {
         <div id="subdomain">
           account
         </div>
-        <img src="/metaweave-dark.svg" alt="metaweave logo">
+        <img src="/metaweave-gradient-dark.svg" alt="metaweave logo">
         <div id="text">
           metaweave.xyz
         </div>

--- a/src/getHtml.ts
+++ b/src/getHtml.ts
@@ -66,7 +66,7 @@ export async function forWeeve (weeve: T_weeve) {
       <body>
         <div id="logo">
         <div id="subdomain">
-          account
+          resolver
         </div>
         <img src="/metaweave-gradient-dark.svg" alt="metaweave logo">
         <div id="text">
@@ -116,7 +116,7 @@ export async function forProfile (basePath:string, address: T_address) {
       <body>
         <div id="logo">
         <div id="subdomain">
-          account
+          resolver
         </div>
         <img src="/metaweave-gradient-dark.svg" alt="metaweave logo">
         <div id="text">


### PR DESCRIPTION
Now autogenerated wallet address images look like this.
![image](https://user-images.githubusercontent.com/3269261/170770013-26faec67-3827-4794-be95-401c7f0fe621.png)

And the splash screen uses the new gradient metaweave logo.

![image](https://user-images.githubusercontent.com/3269261/170770301-97064119-8367-47b9-abc4-b3678c951a5b.png)
